### PR TITLE
Fix buffer overflow. sprintf prints a trailing null.

### DIFF
--- a/src/st.c
+++ b/src/st.c
@@ -4456,7 +4456,7 @@ xrdb_load(void)
 
 		/* handling colors here without macros to do via loop. */
 		int i = 0;
-		char loadValue[11] = "";
+		char loadValue[12] = "";
 		for (i = 0; i < 256; i++)
 		{
 			sprintf(loadValue, "%s%d", "st.color", i);


### PR DESCRIPTION
sprintf will always attempt to write a trailing null, so the length of `st.color255\0` is 12, not 11.